### PR TITLE
Update names to avoid conflict with `SDWebImage/libwebp-Xcode`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,13 +4,13 @@
 import PackageDescription
 
 let package = Package(
-    name: "libwebp",
+    name: "libwebp-ios",
     platforms: [
         .macOS(.v10_10), .iOS(.v13), .macCatalyst(.v14), .tvOS(.v11), .watchOS(.v6)
     ],
     products: [
         .library(
-            name: "libwebp",
+            name: "libwebp-ios",
             targets: ["libwebp", "libwebpmux", "libwebpdemux", "libsharpyuv"]),
     ],
     dependencies: [

--- a/Package.swift
+++ b/Package.swift
@@ -11,14 +11,14 @@ let package = Package(
     products: [
         .library(
             name: "libwebp-ios",
-            targets: ["libwebp", "libwebpmux", "libwebpdemux", "libsharpyuv"]),
+            targets: ["libwebp-ios", "libwebpmux", "libwebpdemux", "libsharpyuv"]),
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
     ],
     targets: [
-        .binaryTarget(name: "libwebp", path: "Sources/libwebp.xcframework"),
+        .binaryTarget(name: "libwebp-ios", path: "Sources/libwebp.xcframework"),
         .binaryTarget(name: "libwebpmux", path: "Sources/libwebpmux.xcframework"),
         .binaryTarget(name: "libwebpdemux", path: "Sources/libwebpdemux.xcframework"),
         .binaryTarget(name: "libsharpyuv", path: "Sources/libsharpyuv.xcframework")


### PR DESCRIPTION
This resolves target/product name conflict with [`SDWebImage/libwebp-Xcode`](https://github.com/SDWebImage/libwebp-Xcode)

We face the error below when trying to use two packages together since both of them provide target and package named `libwebp`.

```
xcodebuild: error: Could not resolve package dependencies: multiple products named 'libwebp' in: 'libwebp-ios', 'libwebp-xcode'

xcodebuild: error: Could not resolve package dependencies:
 multiple targets named 'libwebp' in: 'libwebp-ios', 'libwebp-xcode'; consider using the `moduleAliases` parameter in manifest to provide unique names 
```